### PR TITLE
Fix/pi 2310/migrate from cloudfront to fastly cdn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## v1.7.1
+migrate to fastly CDN for ctv.truex.com
+
+## v1.7.1
 * set cache-control header on all uploaded files
 
 ## v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## v1.7.1
+## v1.7.2
 migrate to fastly CDN for ctv.truex.com
 
 ## v1.7.1

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -4,12 +4,12 @@ This document describes the initial steps needed to make use of the `TruexAdRend
 
 The true[X] ad renderer is available as an `npm` module. For the typical web app based around a `package.json` project file, one adds the true[X] dependency as follows:
 ```sh
-npm add @truex/ctv-ad-renderer
+npm add @truex/ad-renderer
 ```
 this will add an entry in the `"dependencies"` section in the `package.json` file, something like:
 ```json
     "dependencies": {
-        "@truex/ctv-ad-renderer": "1.0.0",
+        "@truex/ad-renderer": "1.12.5",
 ```
 One then builds and runs their web app like usual, e.g. invoking `npm start` for webpack-based projects.
 
@@ -17,7 +17,7 @@ One typically develops web apps in a local browser like Chrome, e.g. referring t
 
 To actually integrate the true[X] ad renderer, one has to create and invoke it during your app's video playback when the time of an ad break is reached. The pattern will look something like:
 ```javascript
-import { TruexAdRenderer } from '@truex/ctv-ad-renderer';
+import { TruexAdRenderer } from '@truex/ad-renderer';
 
 ...
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "TruexRefApp_IMA_CSAI",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1083,32 +1083,19 @@
                 }
             }
         },
-        "@truex/ctv-ad-renderer": {
-            "version": "1.7.13",
-            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.7.13.tgz",
-            "integrity": "sha512-oGeTRhCLL3ioSOEWnvpDK3MLDFP6Xx937jSUgv5vCPad5N3BcHqxiPD7O2719aw0Hoj0o9R87kOJcPKcyhHhgg==",
+        "@truex/ad-renderer": {
+            "version": "1.12.5",
+            "resolved": "https://registry.npmjs.org/@truex/ad-renderer/-/ad-renderer-1.12.5.tgz",
+            "integrity": "sha512-u9k0PnRz/zMRIn43RCsEKhhlDOeBV1WqdNv1KS8AGdMWH24GAwstwP+tc0G1kr3DL8evlsOzBJO4SwZWzGhTMw==",
             "requires": {
                 "bluebird": "^3.5.1",
                 "centralize-js": "^1.1.4",
                 "core-js": "^3.6.4",
                 "lodash.merge": "^4.6.2",
                 "raven-js": "^3.25.2",
-                "truex-shared": "git+https://github.com/socialvibe/truex-shared-js.git#1.7.10",
+                "truex-shared": "git+https://github.com/socialvibe/truex-shared-js.git#1.10.3",
                 "uuid": "^3.4.0",
                 "whatwg-fetch": "^3.0.0"
-            },
-            "dependencies": {
-                "truex-shared": {
-                    "version": "git+https://github.com/socialvibe/truex-shared-js.git#abd1298728e43d46d1032c063235d5c4302a2ea9",
-                    "from": "git+https://github.com/socialvibe/truex-shared-js.git#1.7.10",
-                    "requires": {
-                        "aws-sdk": "^2.260.1",
-                        "edgecast-purge": "^0.1.1",
-                        "node-fetch": "^2.6.1",
-                        "uuid": "^3.4.0",
-                        "whatwg-fetch": "^3.0.0"
-                    }
-                }
             }
         },
         "@types/json-schema": {
@@ -4951,15 +4938,6 @@
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
         },
-        "invalidate-cloudfront-edge-cache": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/invalidate-cloudfront-edge-cache/-/invalidate-cloudfront-edge-cache-1.1.0.tgz",
-            "integrity": "sha512-z6kCRw6NfO+xlwNoWCbK1bXG2QxsLCXOvJRnb1x1Wyk++iZQhb6ZsQjr3BLylWsm9DyMJoEEegnaJuXeowqtZg==",
-            "dev": true,
-            "requires": {
-                "aws-sdk": "^2.749.0"
-            }
-        },
         "is-accessor-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -6068,9 +6046,9 @@
             }
         },
         "node-fetch": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
@@ -8649,8 +8627,8 @@
             }
         },
         "truex-shared": {
-            "version": "git+https://github.com/socialvibe/truex-shared-js.git#3e4fa5cba2d8788be251833ad382e972b9b864f9",
-            "from": "git+https://github.com/socialvibe/truex-shared-js.git#1.7.18",
+            "version": "git+https://github.com/socialvibe/truex-shared-js.git#e760615ff4142e5c7ff6b4845ec8f64085fc2e5b",
+            "from": "git+https://github.com/socialvibe/truex-shared-js.git#1.10.3",
             "requires": {
                 "aws-sdk": "^2.260.1",
                 "edgecast-purge": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "TruexRefApp_IMA_CSAI",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Sample app to demonstrate how to integrate Google IMA using Client-Side Ad Insertion with true[X]'s CTV Web ad renderer",
     "main": "index.js",
     "public": true,
@@ -36,7 +36,6 @@
         "file-loader": "^6.0.0",
         "html-loader": "^1.1.0",
         "html-webpack-plugin": "^3.2.0",
-        "invalidate-cloudfront-edge-cache": "^1.1.0",
         "node-sass": "^4.14.1",
         "promise-to-upload-dist": "^0.0.7",
         "properties-reader": "^2.0.0",
@@ -50,10 +49,10 @@
         "webpack-serve": "^1.0.4"
     },
     "dependencies": {
-        "@truex/ctv-ad-renderer": "1.7.13",
+        "@truex/ad-renderer": "1.12.5",
         "adm-zip": "^0.5.1",
         "core-js": "^3.6.4",
-        "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#1.7.18",
+        "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#1.10.3",
         "uuid": "^3.4.0",
         "video.js": "^7.15.4",
         "videojs-contrib-ads": "^6.9.0",

--- a/src/components/interactive-ad.js
+++ b/src/components/interactive-ad.js
@@ -1,5 +1,5 @@
 import uuid from 'uuid';
-import { TruexAdRenderer } from '@truex/ctv-ad-renderer';
+import { TruexAdRenderer } from '@truex/ad-renderer';
 
 // Exercises the True[X] Ad Renderer for interactive ads.
 // NOTE: this is the main integration point for display interactive ads via the true[X] SDK.

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import { DebugLog } from 'truex-shared/components/debug-log';
 import { inputActions } from 'truex-shared/focus_manager/txm_input_actions';
 import { Focusable } from 'truex-shared/focus_manager/txm_focusable';
 import { TXMFocusManager } from 'truex-shared/focus_manager/txm_focus_manager';
-import { TruexAdRenderer } from '@truex/ctv-ad-renderer';
+import { TruexAdRenderer } from '@truex/ad-renderer';
 import { LoadingSpinner } from "./components/loading-spinner";
 import { v4 as uuid } from 'uuid';
 import videoStreams from "./data/video-streams.json";

--- a/src/simple/simple-video-controller.js
+++ b/src/simple/simple-video-controller.js
@@ -7,7 +7,6 @@ import pauseSvg from '../assets/pause-button.svg';
 import { InteractiveAd } from "../components/interactive-ad";
 
 import vastAdPlaylist from '../data/sample-ad-playlist.xml';
-//import vastAdPlaylist from '../data/AnE-sample-vst-response.xml';
 
 /**
  * Presents a video controller that demonstrates the "simple" use of the client-side ad insertion IMA SDK

--- a/src/simple/simple-video-controller.js
+++ b/src/simple/simple-video-controller.js
@@ -7,6 +7,7 @@ import pauseSvg from '../assets/pause-button.svg';
 import { InteractiveAd } from "../components/interactive-ad";
 
 import vastAdPlaylist from '../data/sample-ad-playlist.xml';
+//import vastAdPlaylist from '../data/AnE-sample-vst-response.xml';
 
 /**
  * Presents a video controller that demonstrates the "simple" use of the client-side ad insertion IMA SDK

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -4,7 +4,7 @@ require('truex-shared/src/deploy/promisify').polyfill();
 
 const s3 = require('truex-shared/src/deploy/s3-upload');
 const uploadDist = require('truex-shared/src/deploy/upload-dist');
-const awsCloudFrontInvalidate = require("invalidate-cloudfront-edge-cache");
+const { purgeFastlyService }  = require("truex-shared/src/deploy/purge-fastly-service");
 
 const deploy = () => {
     const bucket = "ctv.truex.com";
@@ -13,7 +13,6 @@ const deploy = () => {
 
     const PR = process.env.TRAVIS_PULL_REQUEST;
     const isPR = PR != "false";
-    const cloudFrontDistId = process.env.TRUEX_CLOUDFRONT_DISTRIBUTION_ID;
 
     if (isPR) {
         // We only want to deploy on the final merges.
@@ -30,9 +29,9 @@ const deploy = () => {
             return uploadDist(bucket, prefix);
         })
         .then(() => {
-            console.log("invalidating cloudfront cache");
-            const pathsToInvalidate = [`/${prefix}/index.html`];
-            return awsCloudFrontInvalidate(cloudFrontDistId, pathsToInvalidate);
+            // Purge the entire Fastly CDN service for robustness, it is ok performance-wise.
+            // Fastly otherwise makes it difficult to purge related urls, e.g. .../someFile.js vs .../someFile.js?cb=460
+            return purgeFastlyService(bucket, process.env.FASTLY_API_TOKEN);
         })
         .then(() => {
             console.log("deploy complete");

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -8,13 +8,11 @@ const { purgeFastlyService }  = require("truex-shared/src/deploy/purge-fastly-se
 
 const deploy = () => {
     const bucket = "ctv.truex.com";
-    // const branch = process.env.TRAVIS_BRANCH;
-    const branch = 'test'
+    const branch = process.env.TRAVIS_BRANCH;
     const prefix = 'web/ref-app-IMA-CSAI/' + branch;
 
     const PR = process.env.TRAVIS_PULL_REQUEST;
-    // const isPR = PR != "false";
-    const isPR = false;
+    const isPR = PR != "false";
 
     if (isPR) {
         // We only want to deploy on the final merges.

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -8,11 +8,13 @@ const { purgeFastlyService }  = require("truex-shared/src/deploy/purge-fastly-se
 
 const deploy = () => {
     const bucket = "ctv.truex.com";
-    const branch = process.env.TRAVIS_BRANCH;
+    // const branch = process.env.TRAVIS_BRANCH;
+    const branch = 'test'
     const prefix = 'web/ref-app-IMA-CSAI/' + branch;
 
     const PR = process.env.TRAVIS_PULL_REQUEST;
-    const isPR = PR != "false";
+    // const isPR = PR != "false";
+    const isPR = false;
 
     if (isPR) {
         // We only want to deploy on the final merges.


### PR DESCRIPTION
JIRA: [PI-2310](https://infillion.atlassian.net/browse/PI-2310): Migrate deployment scripts from Cloudfront to Fastly CDN caches

Deploy now invokes fastly cache invalidation instead of Cloudfront's.

Test by pushing PRs, merging to develop, merging to master.

TODO: merge only once new fastly-based ctv.truex.com is public

[PI-2310]: https://infillion.atlassian.net/browse/PI-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ