### PR TITLE
Fix/pi 2860/ctv google csai ref app not skipping over truex placeholder video

### DIFF
--- a/src/data/sample-ad-playlist.xml
+++ b/src/data/sample-ad-playlist.xml
@@ -11,7 +11,7 @@
               <AdTitle>TrueX Interactive Preroll</AdTitle>
               <Creatives>
                 <Creative id="truex-preroll" sequence="1">
-                  <Linear skipoffset="00:00:00.01">
+                  <Linear>
                     <Duration>00:00:30</Duration>
                     <AdParameters>
                       <![CDATA[ {"vast_config_url":"get.truex.com/72904fe382372efcdcea6314aa1d7a37db6051b9/vast/config?dimension_1=sample-video&dimension_2=0&dimension_3=sample-video&dimension_4=1234&dimension_5=evergreen&stream_position=preroll&stream_id=#{stream-id}&network_user_id=#{user-id}"}]]>
@@ -57,7 +57,7 @@
               <AdTitle>TrueX Interactive Midroll</AdTitle>
               <Creatives>
                 <Creative id="truex-midroll" sequence="1">
-                  <Linear skipoffset="00:00:00.01">
+                  <Linear>
                     <Duration>00:00:30</Duration>
                     <AdParameters>
                       <![CDATA[ {"vast_config_url":"get.truex.com/72904fe382372efcdcea6314aa1d7a37db6051b9/vast/config?dimension_1=sample-video&dimension_2=1&dimension_3=sample-video&dimension_4=5678&dimension_5=evergreen&stream_position=midroll&stream_id=#{stream-id}&network_user_id=#{user-id}"}]]>

--- a/src/data/sample-ad-playlist.xml
+++ b/src/data/sample-ad-playlist.xml
@@ -11,7 +11,7 @@
               <AdTitle>TrueX Interactive Preroll</AdTitle>
               <Creatives>
                 <Creative id="truex-preroll" sequence="1">
-                  <Linear skipoffset="00:00:00">
+                  <Linear skipoffset="00:00:00.01">
                     <Duration>00:00:30</Duration>
                     <AdParameters>
                       <![CDATA[ {"vast_config_url":"get.truex.com/72904fe382372efcdcea6314aa1d7a37db6051b9/vast/config?dimension_1=sample-video&dimension_2=0&dimension_3=sample-video&dimension_4=1234&dimension_5=evergreen&stream_position=preroll&stream_id=#{stream-id}&network_user_id=#{user-id}"}]]>
@@ -57,7 +57,7 @@
               <AdTitle>TrueX Interactive Midroll</AdTitle>
               <Creatives>
                 <Creative id="truex-midroll" sequence="1">
-                  <Linear skipoffset="00:00:00">
+                  <Linear skipoffset="00:00:00.01">
                     <Duration>00:00:30</Duration>
                     <AdParameters>
                       <![CDATA[ {"vast_config_url":"get.truex.com/72904fe382372efcdcea6314aa1d7a37db6051b9/vast/config?dimension_1=sample-video&dimension_2=1&dimension_3=sample-video&dimension_4=5678&dimension_5=evergreen&stream_position=midroll&stream_id=#{stream-id}&network_user_id=#{user-id}"}]]>

--- a/src/simple/simple-video-controller.js
+++ b/src/simple/simple-video-controller.js
@@ -479,12 +479,12 @@ export class SimpleVideoController {
     }
 
     stepVideo(forward) {
-        // if (this.currentAd) {
-        //     // Don't allow user seeking during ad playback
-        //     // Just show the control bar so the user can see the timeline.
-        //     this.showControlBar();
-        //     return;
-        // }
+        if (this.currentAd) {
+            // Don't allow user seeking during ad playback
+            // Just show the control bar so the user can see the timeline.
+            this.showControlBar();
+            return;
+        }
 
         if (!this.video) return; // user stepping should only happen on an active video
         const currTime = this.currVideoTime;
@@ -546,7 +546,7 @@ export class SimpleVideoController {
 
         } else {
             // Interpret as a seek.
-            //if (this.currentAd) return;  // Don't allow user seeking during ad playback
+            if (this.currentAd) return;  // Don't allow user seeking during ad playback
             const timelineX = Math.max(0, mouseX - timelineBounds.left);
             const timelineRatio = timelineX / timelineBounds.width;
             const videoDuration = this.getVideoDuration();

--- a/src/simple/simple-video-controller.js
+++ b/src/simple/simple-video-controller.js
@@ -273,7 +273,7 @@ export class SimpleVideoController {
         const canSkip = this.adsManager.getAdSkippableState();
         switch (event.type) {
             case google.ima.AdEvent.Type.LOADED:
-                console.log("ad loaded: " + ad.getAdId() + 'canSkip: ' + canSkip + ' duration: ' + ad.getDuration()
+                console.log("ad loaded: " + ad.getAdId() + ' duration: ' + ad.getDuration()
                     + ' pod: ' + ad.getAdPodInfo().getPodIndex());
                 if (!this.adBreakTimes) {
                     this.adBreakTimes = this.adsManager.getCuePoints();
@@ -284,7 +284,7 @@ export class SimpleVideoController {
                 break;
 
             case google.ima.AdEvent.Type.STARTED:
-                console.log("ad started: " + ad.getAdId() + 'canSkip: ' + canSkip + ' duration: ' + ad.getDuration()
+                console.log("ad started: " + ad.getAdId() + ' duration: ' + ad.getDuration()
                     + ' pod: ' + ad.getAdPodInfo().getPodIndex());
                 this.currentAd = ad;
                 this.currentAdProgress = null;
@@ -297,16 +297,18 @@ export class SimpleVideoController {
                 break;
 
             case google.ima.AdEvent.Type.SKIPPED:
-                console.log(`ad skipped: ${ad?.getAdId()} canSkip: ${canSkip}`);
+                console.log('ad skipped: ' + ad?.getAdId());
 
             case google.ima.AdEvent.Type.AD_PROGRESS:
                 this.currentAdProgress = event.getAdData();
-                if (canSkip && this.isShowingTruexAd()) {
-                    // Progressing thru the placeholder video means we should be done with it.
-                    // Skip no longer works as of Dev 2023, version 3.607.0
-                    // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
-                    //this.adsManager.skip();
-                }
+
+                // Progressing thru the placeholder video means we should be done with it.
+                // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
+                // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+                // if (canSkip && this.isShowingTruexAd()) {
+                //     this.adsManager.skip();
+                // }
+
                 this.refresh();
                 break;
 
@@ -564,7 +566,7 @@ export class SimpleVideoController {
     resumeAdPlayback() {
         if (this.adsManager) {
             if (this.isShowingTruexAd()) {
-                // Skip no longer works as of Dev 2023, version 3.607.0
+                // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
                 // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
                 //this.adsManager.skip();
                 // See the adVideo seek below as a work around
@@ -627,7 +629,7 @@ export class SimpleVideoController {
         this.hideControlBar();
         this.pause();
 
-        // Skip no longer works as of Dev 2023, version 3.607.0
+        // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
         // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
         // As such, we try to force the skip directly on the underlying ad video player as a work around.
         var adVideo = this.adUI.querySelector('video');

--- a/src/simple/simple-video-controller.js
+++ b/src/simple/simple-video-controller.js
@@ -565,6 +565,7 @@ export class SimpleVideoController {
 
     resumeAdPlayback() {
         if (this.adsManager) {
+            // Skip over the truex placeholder ad.
             // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
             // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
             // See the adVideo seek below as a work around

--- a/src/simple/simple-video-controller.js
+++ b/src/simple/simple-video-controller.js
@@ -565,12 +565,12 @@ export class SimpleVideoController {
 
     resumeAdPlayback() {
         if (this.adsManager) {
-            if (this.isShowingTruexAd()) {
-                // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
-                // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
-                //this.adsManager.skip();
-                // See the adVideo seek below as a work around
-            }
+            // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
+            // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+            // See the adVideo seek below as a work around
+            // if (this.isShowingTruexAd()) {
+            //     this.adsManager.skip();
+            // }
             console.log("resumed ad playback");
             this.showPlayer(true);
             this.showAdContainer(true);

--- a/src/simple/simple-video-controller.js
+++ b/src/simple/simple-video-controller.js
@@ -303,8 +303,9 @@ export class SimpleVideoController {
                 this.currentAdProgress = event.getAdData();
                 if (canSkip && this.isShowingTruexAd()) {
                     // Progressing thru the placeholder video means we should be done with it.
-                    console.log(`ad progress: ${ad?.getAdId()} canSkip: ${canSkip} progress: ${this.currentAdProgress?.currentTime || 0}`);
-                    this.adsManager.skip();
+                    // Skip no longer works as of Dev 2023, version 3.607.0
+                    // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+                    //this.adsManager.skip();
                 }
                 this.refresh();
                 break;
@@ -476,12 +477,12 @@ export class SimpleVideoController {
     }
 
     stepVideo(forward) {
-        if (this.currentAd) {
-            // Don't allow user seeking during ad playback
-            // Just show the control bar so the user can see the timeline.
-            this.showControlBar();
-            return;
-        }
+        // if (this.currentAd) {
+        //     // Don't allow user seeking during ad playback
+        //     // Just show the control bar so the user can see the timeline.
+        //     this.showControlBar();
+        //     return;
+        // }
 
         if (!this.video) return; // user stepping should only happen on an active video
         const currTime = this.currVideoTime;
@@ -543,7 +544,7 @@ export class SimpleVideoController {
 
         } else {
             // Interpret as a seek.
-            if (this.currentAd) return;  // Don't allow user seeking during ad playback
+            //if (this.currentAd) return;  // Don't allow user seeking during ad playback
             const timelineX = Math.max(0, mouseX - timelineBounds.left);
             const timelineRatio = timelineX / timelineBounds.width;
             const videoDuration = this.getVideoDuration();
@@ -563,7 +564,10 @@ export class SimpleVideoController {
     resumeAdPlayback() {
         if (this.adsManager) {
             if (this.isShowingTruexAd()) {
-                this.adsManager.skip();
+                // Skip no longer works as of Dev 2023, version 3.607.0
+                // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+                //this.adsManager.skip();
+                // See the adVideo seek below as a work around
             }
             console.log("resumed ad playback");
             this.showPlayer(true);
@@ -622,6 +626,14 @@ export class SimpleVideoController {
         this.showLoadingSpinner(true);
         this.hideControlBar();
         this.pause();
+
+        // Skip no longer works as of Dev 2023, version 3.607.0
+        // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+        // As such, we try to force the skip directly on the underlying ad video player as a work around.
+        var adVideo = this.adUI.querySelector('video');
+        if (adVideo && adVideo.duration > 0) {
+            adVideo.currentTime = adVideo.duration;
+        }
 
         // Start an interactive ad.
         const interactiveAd = new InteractiveAd(vastConfigUrl, this);

--- a/src/videojs/videojs-controller.js
+++ b/src/videojs/videojs-controller.js
@@ -179,6 +179,7 @@ export class VideoJSController {
             this.adsManager.addEventListener(google.ima.AdEvent.Type.LOADED, this.onAdEvent);
             this.adsManager.addEventListener(google.ima.AdEvent.Type.STARTED, this.onAdEvent);
             this.adsManager.addEventListener(google.ima.AdEvent.Type.AD_PROGRESS, this.onAdEvent);
+            this.adsManager.addEventListener(google.ima.AdEvent.Type.SKIPPED, this.onAdEvent);
             this.adsManager.addEventListener(google.ima.AdEvent.Type.COMPLETE, this.onAdEvent);
             this.adsManager.addEventListener(google.ima.AdEvent.Type.ALL_ADS_COMPLETED, this.onAdEvent);
 
@@ -222,10 +223,11 @@ export class VideoJSController {
     onAdEvent(event) {
         // Retrieve the ad from the event. Some events (e.g. ALL_ADS_COMPLETED)
         // don't have ad object associated.
-        const ad = event.getAd();
+        const ad = event.getAd() || this.currentAd;
+        const canSkip = this.adsManager.getAdSkippableState();
         switch (event.type) {
             case google.ima.AdEvent.Type.LOADED:
-                console.log("ad loaded: " + ad.getAdId() + ' duration: ' + ad.getDuration()
+                console.log('ad loaded: ' + ad.getAdId() + ' canSkip: ' + canSkip + ' duration: ' + ad.getDuration()
                     + ' pod: ' + ad.getAdPodInfo().getPodIndex());
                 if (!this.adBreakTimes) {
                     this.adBreakTimes = this.adsManager.getCuePoints();
@@ -236,7 +238,7 @@ export class VideoJSController {
                 break;
 
             case google.ima.AdEvent.Type.STARTED:
-                console.log("ad started: " + ad.getAdId() + ' duration: ' + ad.getDuration()
+                console.log('ad started: ' + ad.getAdId() + ' canSkip: ' + canSkip + ' duration: ' + ad.getDuration()
                     + ' pod: ' + ad.getAdPodInfo().getPodIndex());
                 this.currentAd = ad;
                 this.currentAdProgress = null;
@@ -248,8 +250,16 @@ export class VideoJSController {
                 this.startInteractiveAd();
                 break;
 
+            case google.ima.AdEvent.Type.SKIPPED:
+                console.log("ad skipped: canSkip: " + canSkip);
+
             case google.ima.AdEvent.Type.AD_PROGRESS:
                 this.currentAdProgress = event.getAdData();
+                if (canSkip && this.isShowingTruexAd()) {
+                    // Progressing thru the placeholder video means we should be done with it.
+                    console.log(`ad progress: ${ad?.getAdId()} canSkip: ${canSkip} progress: ${this.currentAdProgress?.currentTime || 0}`);
+                    this.adsManager.skip();
+                }
                 this.refresh();
                 break;
 

--- a/src/videojs/videojs-controller.js
+++ b/src/videojs/videojs-controller.js
@@ -257,8 +257,9 @@ export class VideoJSController {
                 this.currentAdProgress = event.getAdData();
                 if (canSkip && this.isShowingTruexAd()) {
                     // Progressing thru the placeholder video means we should be done with it.
-                    console.log(`ad progress: ${ad?.getAdId()} canSkip: ${canSkip} progress: ${this.currentAdProgress?.currentTime || 0}`);
-                    this.adsManager.skip();
+                    // Skip no longer works as of Dev 2023, version 3.607.0
+                    // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+                    //this.adsManager.skip();
                 }
                 this.refresh();
                 break;
@@ -501,7 +502,10 @@ export class VideoJSController {
         if (this.adsManager) {
             if (this.isShowingTruexAd()) {
                 // Skip over the truex placeholder ad.
-                this.adsManager.skip();
+                // Skip no longer works as of Dev 2023, version 3.607.0
+                // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+                //this.adsManager.skip();
+                // See the adVideo seek below as a work around
             }
             console.log("resumed ad playback");
             this.showPlayer(true);
@@ -553,6 +557,14 @@ export class VideoJSController {
         this.showLoadingSpinner(true);
         this.hideControlBar();
         this.pause();
+
+        // Skip no longer works as of Dev 2023, version 3.607.0
+        // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+        // As such, we try to force the skip directly on the underlying ad video player as a work around.
+        var adVideo = this.videoOwner.querySelector('.ima-ad-container video');
+        if (adVideo && adVideo.duration > 0) {
+            adVideo.currentTime = adVideo.duration;
+        }
 
         // Start an interactive ad.
         const interactiveAd = new InteractiveAd(vastConfigUrl, this);

--- a/src/videojs/videojs-controller.js
+++ b/src/videojs/videojs-controller.js
@@ -502,13 +502,13 @@ export class VideoJSController {
 
     resumeAdPlayback() {
         if (this.adsManager) {
-            if (this.isShowingTruexAd()) {
-                // Skip over the truex placeholder ad.
-                // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
-                // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
-                //this.adsManager.skip();
-                // See the adVideo seek below as a work around
-            }
+            // Skip over the truex placeholder ad.
+            // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
+            // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+            // See the adVideo seek below as a work around
+            // if (this.isShowingTruexAd()) {
+            //     this.adsManager.skip();
+            // }
             console.log("resumed ad playback");
             this.showPlayer(true);
             this.showAdContainer(true);

--- a/src/videojs/videojs-controller.js
+++ b/src/videojs/videojs-controller.js
@@ -227,7 +227,7 @@ export class VideoJSController {
         const canSkip = this.adsManager.getAdSkippableState();
         switch (event.type) {
             case google.ima.AdEvent.Type.LOADED:
-                console.log('ad loaded: ' + ad.getAdId() + ' canSkip: ' + canSkip + ' duration: ' + ad.getDuration()
+                console.log('ad loaded: ' + ad.getAdId() + ' duration: ' + ad.getDuration()
                     + ' pod: ' + ad.getAdPodInfo().getPodIndex());
                 if (!this.adBreakTimes) {
                     this.adBreakTimes = this.adsManager.getCuePoints();
@@ -238,7 +238,7 @@ export class VideoJSController {
                 break;
 
             case google.ima.AdEvent.Type.STARTED:
-                console.log('ad started: ' + ad.getAdId() + ' canSkip: ' + canSkip + ' duration: ' + ad.getDuration()
+                console.log('ad started: ' + ad.getAdId() + ' duration: ' + ad.getDuration()
                     + ' pod: ' + ad.getAdPodInfo().getPodIndex());
                 this.currentAd = ad;
                 this.currentAdProgress = null;
@@ -251,16 +251,18 @@ export class VideoJSController {
                 break;
 
             case google.ima.AdEvent.Type.SKIPPED:
-                console.log("ad skipped: canSkip: " + canSkip);
+                console.log('ad skipped: ' + ad?.getAdId());
 
             case google.ima.AdEvent.Type.AD_PROGRESS:
                 this.currentAdProgress = event.getAdData();
-                if (canSkip && this.isShowingTruexAd()) {
-                    // Progressing thru the placeholder video means we should be done with it.
-                    // Skip no longer works as of Dev 2023, version 3.607.0
-                    // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
-                    //this.adsManager.skip();
-                }
+
+                // Progressing thru the placeholder video means we should be done with it.
+                // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
+                // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
+                // if (canSkip && this.isShowingTruexAd()) {
+                //     this.adsManager.skip();
+                // }
+
                 this.refresh();
                 break;
 
@@ -502,7 +504,7 @@ export class VideoJSController {
         if (this.adsManager) {
             if (this.isShowingTruexAd()) {
                 // Skip over the truex placeholder ad.
-                // Skip no longer works as of Dev 2023, version 3.607.0
+                // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
                 // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
                 //this.adsManager.skip();
                 // See the adVideo seek below as a work around
@@ -558,7 +560,7 @@ export class VideoJSController {
         this.hideControlBar();
         this.pause();
 
-        // Skip no longer works as of Dev 2023, version 3.607.0
+        // NOTE: Skip no longer works as of Dev 2023, version 3.607.0
         // See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
         // As such, we try to force the skip directly on the underlying ad video player as a work around.
         var adVideo = this.videoOwner.querySelector('.ima-ad-container video');


### PR DESCRIPTION
Jira: [PI-2860](https://infillion.atlassian.net/browse/PI-2860) CTV google CSAI ref app not skipping over Truex placeholder video

Basically, skip no longer works as of Dev 2023, version 3.607.0
See: https://groups.google.com/g/ima-sdk/c/ky-Q_pUXrIA
As such, we try to force the skip directly on the underlying ad video player as a work around.


[PI-2860]: https://infillion.atlassian.net/browse/PI-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ