### PR TITLE
Fix/pi 2860/ctv google csai ref app not skipping over truex placeholder video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## v1.7.3
-work around decprecated adManager.skip() method
+work around deprecated adManager.skip() method
 
 ## v1.7.2
 migrate to fastly CDN for ctv.truex.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.7.3
+work around decprecated adManager.skip() method
+
 ## v1.7.2
 migrate to fastly CDN for ctv.truex.com
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "TruexRefApp_IMA_CSAI",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "description": "Sample app to demonstrate how to integrate Google IMA using Client-Side Ad Insertion with true[X]'s CTV Web ad renderer",
     "main": "index.js",
     "public": true,


### PR DESCRIPTION
forgot the version bump
continuation of the [last PR](https://github.com/socialvibe/truex-ctv-google-ima-csai-ref-app/pull/16)